### PR TITLE
CORE: Remove uuid on push - SP-10935

### DIFF
--- a/src/commands/sharinpix/form/csv2json.ts
+++ b/src/commands/sharinpix/form/csv2json.ts
@@ -1,21 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { parse } from 'csv-parse/sync';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { getCsvFiles, formatErrorMessage, orderElementKeys } from '../../../helpers/utils.js';
 import { parseCell } from '../../../helpers/form/elementKeys.js';
+import { parseCsv } from '../../../helpers/csv.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@sharinpix/sharinpix-sf-cli', 'sharinpix.form.csv2json');
 
 const FORMS_DIRECTORY = 'sharinpix/forms';
-
-const CSV_PARSE_OPTIONS = {
-  skipEmptyLines: true,
-  relaxColumnCount: true,
-  relaxQuotes: true,
-} as const;
 
 export type Csv2JsonResult = {
   name: string;
@@ -25,10 +19,6 @@ export type Csv2JsonResult = {
 
 type FormElement = Record<string, unknown>;
 type ProcessResult = { success: true; fileName: string } | { success: false; fileName: string; reason: string };
-
-function parseCsvRows(content: string): string[][] {
-  return parse(content, CSV_PARSE_OPTIONS) as string[][];
-}
 
 function mergeElementsIntoJson(
   existingJson: Record<string, unknown>,
@@ -110,7 +100,7 @@ async function processCsvFile(filePath: string): Promise<ProcessResult> {
 
   try {
     const content = await fs.promises.readFile(filePath, 'utf8');
-    const rows = parseCsvRows(content);
+    const rows = parseCsv(content);
 
     if (rows.length < 2) throw new Error(messages.getMessage('error.noDataRows'));
 

--- a/src/commands/sharinpix/form/csv2json.ts
+++ b/src/commands/sharinpix/form/csv2json.ts
@@ -27,7 +27,7 @@ type FormElement = Record<string, unknown>;
 type ProcessResult = { success: true; fileName: string } | { success: false; fileName: string; reason: string };
 
 function parseCsvRows(content: string): string[][] {
-  return parse(content, CSV_PARSE_OPTIONS);
+  return parse(content, CSV_PARSE_OPTIONS) as string[][];
 }
 
 function mergeElementsIntoJson(

--- a/src/commands/sharinpix/form/push.ts
+++ b/src/commands/sharinpix/form/push.ts
@@ -9,6 +9,7 @@ import {
   getJsonFiles,
   fetchJson,
   formatErrorMessage,
+  stripRootUuid,
 } from '../../../helpers/utils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -94,6 +95,7 @@ export default class Push extends SfCommand<PushResult> {
       const processFile = async (): Promise<void> => {
         const json = readJsonFile(file);
         const fileName = getNameFromJson(json);
+        const jsonForPush = stripRootUuid(json);
         const existingRecord = existingMap.get(fileName);
         const existingId = existingRecord?.Id ?? null;
 
@@ -103,7 +105,12 @@ export default class Push extends SfCommand<PushResult> {
             return null;
           });
 
-          if (existingJson && isJsonEqual(json, existingJson)) {
+          if (
+            existingJson &&
+            typeof existingJson === 'object' &&
+            !Array.isArray(existingJson) &&
+            isJsonEqual(jsonForPush, stripRootUuid(existingJson as Record<string, unknown>))
+          ) {
             this.log(messages.getMessage('info.skipped', [fileName]));
             skipped++;
             return;
@@ -116,7 +123,7 @@ export default class Push extends SfCommand<PushResult> {
             sfid: existingId ?? undefined,
             config: {
               name: fileName,
-              ...(json as object),
+              ...jsonForPush,
             },
           }),
           headers: {
@@ -133,7 +140,7 @@ export default class Push extends SfCommand<PushResult> {
         const responseData = (await response.json()) as { url: string };
 
         const formTemplateJson = JSON.stringify({
-          ...(json as object),
+          ...jsonForPush,
           url: responseData.url,
         });
 

--- a/src/helpers/csv.ts
+++ b/src/helpers/csv.ts
@@ -1,0 +1,22 @@
+import { parse } from 'csv-parse/sync';
+
+export const CSV_PARSE_OPTIONS = {
+  skipEmptyLines: true,
+  relaxColumnCount: true,
+  relaxQuotes: true,
+} as const;
+
+function isStringMatrix(value: unknown): value is string[][] {
+  return (
+    Array.isArray(value) &&
+    value.every((row) => Array.isArray(row) && row.every((cell) => typeof cell === 'string'))
+  );
+}
+
+export function parseCsv(content: string, options = CSV_PARSE_OPTIONS): string[][] {
+  const result: unknown = parse(content, options);
+  if (!isStringMatrix(result)) {
+    throw new Error('Failed to parse CSV content');
+  }
+  return result;
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -6,6 +6,12 @@ export function isJsonEqual(obj1: unknown, obj2: unknown): boolean {
   return JSON.stringify(obj1) === JSON.stringify(obj2);
 }
 
+export function stripRootUuid(json: Record<string, unknown>): Record<string, unknown> {
+  const rest = { ...json };
+  delete rest.uuid;
+  return rest;
+}
+
 export function createSafeFilename(name: string): string {
   const md5Hash = crypto.createHash('md5').update(name).digest('hex').slice(0, 8);
   return `${name.replaceAll(/[^a-zA-Z0-9]/g, '_')}-${md5Hash}`;

--- a/test/commands/sharinpix/form/csv2json.test.ts
+++ b/test/commands/sharinpix/form/csv2json.test.ts
@@ -442,7 +442,7 @@ describe('sharinpix form csv2json', () => {
     expect(fs.existsSync('sharinpix/forms/CsvRoundTrip.csv')).to.be.true;
 
     const outCsv = fs.readFileSync('sharinpix/forms/CsvRoundTrip.csv', 'utf8');
-    const rows = parse(outCsv, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true });
+    const rows = parse(outCsv, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true }) as string[][];
     const headers = rows[0] ?? [];
     const dataRow = rows[1] ?? [];
     const record: Record<string, string> = {};

--- a/test/commands/sharinpix/form/csv2json.test.ts
+++ b/test/commands/sharinpix/form/csv2json.test.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs';
 import { TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
-import { parse } from 'csv-parse/sync';
 import mock from 'mock-fs';
 import Csv2Json from '../../../../src/commands/sharinpix/form/csv2json.js';
 import Json2Csv from '../../../../src/commands/sharinpix/form/json2csv.js';
+import { parseCsv } from '../../../../src/helpers/csv.js';
 
 describe('sharinpix form csv2json', () => {
   const $$ = new TestContext();
@@ -442,7 +442,7 @@ describe('sharinpix form csv2json', () => {
     expect(fs.existsSync('sharinpix/forms/CsvRoundTrip.csv')).to.be.true;
 
     const outCsv = fs.readFileSync('sharinpix/forms/CsvRoundTrip.csv', 'utf8');
-    const rows = parse(outCsv, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true }) as string[][];
+    const rows = parseCsv(outCsv);
     const headers = rows[0] ?? [];
     const dataRow = rows[1] ?? [];
     const record: Record<string, string> = {};

--- a/test/commands/sharinpix/form/json2csv.test.ts
+++ b/test/commands/sharinpix/form/json2csv.test.ts
@@ -236,7 +236,7 @@ describe('sharinpix form json2csv', () => {
       skipEmptyLines: true,
       relaxColumnCount: true,
       relaxQuotes: true,
-    });
+    }) as string[][];
     const headers: string[] = rows[0] ?? [];
     const row1: string[] = rows[1] ?? [];
     const row2: string[] = rows[2] ?? [];
@@ -347,7 +347,7 @@ describe('sharinpix form json2csv', () => {
         expect(fs.existsSync(csvPath)).to.be.true;
 
         const csvContent = fs.readFileSync(csvPath, 'utf8');
-        const rows = parse(csvContent, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true });
+        const rows = parse(csvContent, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true }) as string[][];
         const headers: string[] = rows[0] ?? [];
 
         const original = originalJson as { elements?: Array<Record<string, unknown>> };

--- a/test/commands/sharinpix/form/json2csv.test.ts
+++ b/test/commands/sharinpix/form/json2csv.test.ts
@@ -4,10 +4,10 @@ import { fileURLToPath } from 'node:url';
 import { TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
-import { parse } from 'csv-parse/sync';
 import mock from 'mock-fs';
 import Json2Csv from '../../../../src/commands/sharinpix/form/json2csv.js';
 import Csv2Json from '../../../../src/commands/sharinpix/form/csv2json.js';
+import { parseCsv } from '../../../../src/helpers/csv.js';
 import { elementKeyOrder } from '../../../../src/helpers/form/elementKeys.js';
 
 function schemaHeadersFromKeys(allKeys: Set<string>): string[] {
@@ -232,11 +232,7 @@ describe('sharinpix form json2csv', () => {
     expect(fs.existsSync('sharinpix/forms/EmptyStringMissing.csv')).to.be.true;
 
     const csvContent = fs.readFileSync('sharinpix/forms/EmptyStringMissing.csv', 'utf8');
-    const rows = parse(csvContent, {
-      skipEmptyLines: true,
-      relaxColumnCount: true,
-      relaxQuotes: true,
-    }) as string[][];
+    const rows = parseCsv(csvContent);
     const headers: string[] = rows[0] ?? [];
     const row1: string[] = rows[1] ?? [];
     const row2: string[] = rows[2] ?? [];
@@ -347,7 +343,7 @@ describe('sharinpix form json2csv', () => {
         expect(fs.existsSync(csvPath)).to.be.true;
 
         const csvContent = fs.readFileSync(csvPath, 'utf8');
-        const rows = parse(csvContent, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true }) as string[][];
+        const rows = parseCsv(csvContent);
         const headers: string[] = rows[0] ?? [];
 
         const original = originalJson as { elements?: Array<Record<string, unknown>> };

--- a/test/helpers/utils.test.ts
+++ b/test/helpers/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { isJsonEqual, createSafeFilename } from '../../src/helpers/utils.js';
+import { isJsonEqual, createSafeFilename, stripRootUuid } from '../../src/helpers/utils.js';
 
 describe('Utils', () => {
   describe('isJsonEqual function', () => {
@@ -106,6 +106,36 @@ describe('Utils', () => {
       expect(isJsonEqual(undefined, undefined)).to.be.true;
       expect(isJsonEqual(undefined, null)).to.be.false;
       expect(isJsonEqual(undefined, {})).to.be.false;
+    });
+  });
+
+  describe('stripRootUuid function', () => {
+    it('should remove root-level uuid', () => {
+      const json = {
+        name: 'Test Form',
+        uuid: '12345',
+        elements: [{ id: '1', uuid: 'nested' }],
+      };
+
+      expect(stripRootUuid(json)).to.deep.equal({
+        name: 'Test Form',
+        elements: [{ id: '1', uuid: 'nested' }],
+      });
+    });
+
+    it('should return a copy unchanged when uuid is absent', () => {
+      const json = { name: 'Test Form', elements: [] };
+
+      expect(stripRootUuid(json)).to.deep.equal(json);
+      expect(stripRootUuid(json)).to.not.equal(json);
+    });
+
+    it('should not mutate the original object', () => {
+      const json = { name: 'Test Form', uuid: '12345' };
+
+      stripRootUuid(json);
+
+      expect(json).to.deep.equal({ name: 'Test Form', uuid: '12345' });
     });
   });
 


### PR DESCRIPTION
## Main use case (User story)
+ When pushing json from org A to org B, the key uuid at the root of the json cause will cause error in the org B since uuid are generated in SF and unique per form templates.

## How? (Comments on implementation) 
+ Strip uuid on form push.

## QA Test Steps:
+ All test should pass.

## PR checklist:

- [x]  I reviewed my code
- [ ]  I have written a test for it
- [x]  Commits are meaningful
- [ ]  Tested on the review app and automated QA tests passed
- [x]  The business case and why we want this change is well described here SP-10935