### PR TITLE
CORE: Fix lint and build error - SP-10998

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^8",
     "@salesforce/sf-plugins-core": "^12",
-    "csv": "^6.4.1"
+    "csv": "^6.4.1",
+    "csv-parse": "^6.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/test/commands/sharinpix/form/csv2json.test.ts
+++ b/test/commands/sharinpix/form/csv2json.test.ts
@@ -442,7 +442,11 @@ describe('sharinpix form csv2json', () => {
     expect(fs.existsSync('sharinpix/forms/CsvRoundTrip.csv')).to.be.true;
 
     const outCsv = fs.readFileSync('sharinpix/forms/CsvRoundTrip.csv', 'utf8');
-    const rows = parse(outCsv, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true });
+    const rows = parse(outCsv, {
+      skipEmptyLines: true,
+      relaxColumnCount: true,
+      relaxQuotes: true,
+    });
     const headers = rows[0] ?? [];
     const dataRow = rows[1] ?? [];
     const record: Record<string, string> = {};

--- a/test/commands/sharinpix/form/json2csv.test.ts
+++ b/test/commands/sharinpix/form/json2csv.test.ts
@@ -347,7 +347,11 @@ describe('sharinpix form json2csv', () => {
         expect(fs.existsSync(csvPath)).to.be.true;
 
         const csvContent = fs.readFileSync(csvPath, 'utf8');
-        const rows = parse(csvContent, { skipEmptyLines: true, relaxColumnCount: true, relaxQuotes: true });
+        const rows = parse(csvContent, {
+          skipEmptyLines: true,
+          relaxColumnCount: true,
+          relaxQuotes: true,
+        });
         const headers: string[] = rows[0] ?? [];
 
         const original = originalJson as { elements?: Array<Record<string, unknown>> };


### PR DESCRIPTION
Main use case (User story)
+ We need to add `csv-parse@^6.1.0` to fix lint and build error.

QA Test Steps:
+ Run yarn install.
+ Run yarn build.
+ Confirm lint and compilation pass.
+ Run the CSV/JSON conversion tests and confirm all 25 pass.