### PR TITLE
Remove uuid from json on push  - SP-10935

### DIFF
--- a/src/commands/sharinpix/form/push.ts
+++ b/src/commands/sharinpix/form/push.ts
@@ -9,6 +9,7 @@ import {
   getJsonFiles,
   fetchJson,
   formatErrorMessage,
+  stripRootUuid,
 } from '../../../helpers/utils.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -94,6 +95,7 @@ export default class Push extends SfCommand<PushResult> {
       const processFile = async (): Promise<void> => {
         const json = readJsonFile(file);
         const fileName = getNameFromJson(json);
+        const jsonForPush = stripRootUuid(json);
         const existingRecord = existingMap.get(fileName);
         const existingId = existingRecord?.Id ?? null;
 
@@ -103,7 +105,12 @@ export default class Push extends SfCommand<PushResult> {
             return null;
           });
 
-          if (existingJson && isJsonEqual(json, existingJson)) {
+          if (
+            existingJson &&
+            typeof existingJson === 'object' &&
+            !Array.isArray(existingJson) &&
+            isJsonEqual(jsonForPush, stripRootUuid(existingJson as Record<string, unknown>))
+          ) {
             this.log(messages.getMessage('info.skipped', [fileName]));
             skipped++;
             return;
@@ -116,7 +123,7 @@ export default class Push extends SfCommand<PushResult> {
             sfid: existingId ?? undefined,
             config: {
               name: fileName,
-              ...(json as object),
+              ...jsonForPush,
             },
           }),
           headers: {
@@ -133,7 +140,7 @@ export default class Push extends SfCommand<PushResult> {
         const responseData = (await response.json()) as { url: string };
 
         const formTemplateJson = JSON.stringify({
-          ...(json as object),
+          ...jsonForPush,
           url: responseData.url,
         });
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -6,6 +6,12 @@ export function isJsonEqual(obj1: unknown, obj2: unknown): boolean {
   return JSON.stringify(obj1) === JSON.stringify(obj2);
 }
 
+export function stripRootUuid(json: Record<string, unknown>): Record<string, unknown> {
+  const rest = { ...json };
+  delete rest.uuid;
+  return rest;
+}
+
 export function createSafeFilename(name: string): string {
   const md5Hash = crypto.createHash('md5').update(name).digest('hex').slice(0, 8);
   return `${name.replaceAll(/[^a-zA-Z0-9]/g, '_')}-${md5Hash}`;

--- a/test/commands/sharinpix/form/push.test.ts
+++ b/test/commands/sharinpix/form/push.test.ts
@@ -86,7 +86,8 @@ describe('sharinpix form push', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     mock({
       'sharinpix/forms': {
-        'Form_1-xxxx.json': '{"name":"Form 1","fieldA":true}',
+        'Form_1-xxxx.json':
+          '{"name":"Form 1","uuid":"source-org-uuid","fieldA":true,"elements":[{"uuid":"nested-uuid"}]}',
         'Invalid_Json-xxxx.json': 'invalid-json',
       },
     });
@@ -146,6 +147,18 @@ describe('sharinpix form push', () => {
     expect(result.failed).to.equal(1);
     expect(result.skipped).to.equal(0);
     expect(result.deleted).to.equal(0);
+
+    const uploadRequest = fetchStub.secondCall.args[1] as { body: string };
+    const uploadBody = JSON.parse(uploadRequest.body) as {
+      config: Record<string, unknown>;
+    };
+    expect(uploadBody.config).to.not.have.property('uuid');
+    expect(uploadBody.config.elements).to.deep.equal([{ uuid: 'nested-uuid' }]);
+
+    const importPayload = apexStub.post.secondCall.args[1] as { formTemplateJson: string };
+    const importedJson = JSON.parse(importPayload.formTemplateJson) as Record<string, unknown>;
+    expect(importedJson).to.not.have.property('uuid');
+    expect(importedJson.elements).to.deep.equal([{ uuid: 'nested-uuid' }]);
 
     mock.restore();
   });

--- a/test/helpers/utils.test.ts
+++ b/test/helpers/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { isJsonEqual, createSafeFilename } from '../../src/helpers/utils.js';
+import { isJsonEqual, createSafeFilename, stripRootUuid } from '../../src/helpers/utils.js';
 
 describe('Utils', () => {
   describe('isJsonEqual function', () => {
@@ -106,6 +106,36 @@ describe('Utils', () => {
       expect(isJsonEqual(undefined, undefined)).to.be.true;
       expect(isJsonEqual(undefined, null)).to.be.false;
       expect(isJsonEqual(undefined, {})).to.be.false;
+    });
+  });
+
+  describe('stripRootUuid function', () => {
+    it('should remove root-level uuid', () => {
+      const json = {
+        name: 'Test Form',
+        uuid: '12345',
+        elements: [{ id: '1', uuid: 'nested' }],
+      };
+
+      expect(stripRootUuid(json)).to.deep.equal({
+        name: 'Test Form',
+        elements: [{ id: '1', uuid: 'nested' }],
+      });
+    });
+
+    it('should return a copy unchanged when uuid is absent', () => {
+      const json = { name: 'Test Form', elements: [] };
+
+      expect(stripRootUuid(json)).to.deep.equal(json);
+      expect(stripRootUuid(json)).to.not.equal(json);
+    });
+
+    it('should not mutate the original object', () => {
+      const json = { name: 'Test Form', uuid: '12345' };
+
+      stripRootUuid(json);
+
+      expect(json).to.deep.equal({ name: 'Test Form', uuid: '12345' });
     });
   });
 


### PR DESCRIPTION
## Main use case (User story)
+ When pushing json from org A to org B, the key uuid at the root of the json cause will cause error in the org B since uuid are generated in SF and unique per form templates.

## How? (Comments on implementation) 
+ Strip uuid on form push.

## QA Test Steps:
+ All test should pass.