### PR TITLE
Pin oclif/core to 4.11.11 - SP-11053

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,10 +175,12 @@
   "type": "module",
   "author": "SharinPix",
   "resolutions": {
-    "@types/node": "^20.5.1"
+    "@types/node": "^20.5.1",
+    "@oclif/core": "4.11.11"
   },
   "overrides": {
-    "@types/node": "^20.5.1"
+    "@types/node": "^20.5.1",
+    "@oclif/core": "4.11.11"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,10 +1598,10 @@
     proc-log "^6.0.0"
     which "^6.0.0"
 
-"@oclif/core@^4", "@oclif/core@^4.5.2", "@oclif/core@^4.8.0":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.8.2.tgz#b4bb065b44da9eb2719086854b009a6747455d09"
-  integrity sha512-P+XAOtuWM/Fewau64c31bYUiLFJTzhth229xVbBrG1siLc7+2uezUYhP5eWn/++nZPZ/wChSqYgQNN4HPw/ZHQ==
+"@oclif/core@4.11.11", "@oclif/core@^4", "@oclif/core@^4.5.2", "@oclif/core@^4.8.0":
+  version "4.11.11"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.11.11.tgz#bd5c7d79285c12a43e5830b3362773dbe6048878"
+  integrity sha512-LoGzrvkH9I8dwhxuLafcf90MAp+fYfAiAhpyixaVAWaclIgs+vXeMMQwBG90/wqjdygIKcFAqNnNJrfl3s3X8Q==
   dependencies:
     ansi-escapes "^4.3.2"
     ansis "^3.17.0"
@@ -1613,11 +1613,11 @@
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     lilconfig "^3.1.3"
-    minimatch "^10.2.4"
-    semver "^7.7.3"
+    minimatch "^10.2.5"
+    semver "^7.8.1"
     string-width "^4.2.3"
     supports-color "^8"
-    tinyglobby "^0.2.14"
+    tinyglobby "^0.2.17"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -3414,6 +3414,13 @@ brace-expansion@^5.0.2:
   dependencies:
     balanced-match "^4.0.2"
 
+brace-expansion@^5.0.5:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+  dependencies:
+    balanced-match "^4.0.2"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
@@ -5025,6 +5032,11 @@ fdir@^6.4.4:
   version "6.4.6"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz"
   integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 figures@^2.0.0:
   version "2.0.0"
@@ -7251,6 +7263,13 @@ minimatch@^10.0.3, minimatch@^10.1.1, minimatch@^10.2.2, minimatch@^10.2.4:
   dependencies:
     brace-expansion "^5.0.2"
 
+minimatch@^10.2.5:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -8263,6 +8282,11 @@ picomatch@^4.0.2:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
@@ -8964,6 +8988,11 @@ semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semve
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.8.1:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 sentence-case@^3.0.4:
   version "3.0.4"
@@ -9732,6 +9761,14 @@ tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.9:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 tldts-core@^6.1.86:
   version "6.1.86"


### PR DESCRIPTION
## Main use case (User story)
+ Pin oclif/core to version `4.11.1` because we get this error when doing `yarn run build`:

```bash
yarn run build
yarn run v1.22.22
$ wireit

❌ [compile] exited with exit code 1. Output:

src/commands/sharinpix/config/pull.ts:20:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

20   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/config/push.ts:20:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

20   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/form/pull.ts:29:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

29   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/form/push.ts:37:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

37   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/permission/pull.ts:29:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

29   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/permission/push.ts:36:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

36   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/pull.ts:22:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

22   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/push.ts:22:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

22   public static readonly flags = {
                            ~~~~~

src/commands/sharinpix/settings.ts:14:26 - error TS2742: The inferred type of 'flags' cannot be named without a reference to '@salesforce/sf-plugins-core/node_modules/@oclif/core/interfaces'. This is likely not portable. A type annotation is necessary.

14   public static readonly flags = {
                            ~~~~~


Found 9 errors in 9 files.

Errors  Files
     1  src/commands/sharinpix/config/pull.ts:20
     1  src/commands/sharinpix/config/push.ts:20
     1  src/commands/sharinpix/form/pull.ts:29
     1  src/commands/sharinpix/form/push.ts:37
     1  src/commands/sharinpix/permission/pull.ts:29
     1  src/commands/sharinpix/permission/push.ts:36
     1  src/commands/sharinpix/pull.ts:22
     1  src/commands/sharinpix/push.ts:22
     1  src/commands/sharinpix/settings.ts:14
❌ 1 script failed.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## How? (Comments on implementation) 
+ Add `"@oclif/core": "4.11.11"` in package.json

## QA Test Steps:
+ Run `yarn run build` without errors.
+ All test should pass.