### PR TITLE
CORE: Strip uuid when pulling form - SP-10935

### DIFF
--- a/src/commands/sharinpix/form/pull.ts
+++ b/src/commands/sharinpix/form/pull.ts
@@ -71,7 +71,16 @@ export default class Pull extends SfCommand<PullResult> {
 
         const form: unknown = await response.json();
         const safeFilename = createSafeFilename(record.Name);
-        fs.writeFileSync(`sharinpix/forms/${safeFilename}.json`, JSON.stringify(form, null, 2));
+        fs.writeFileSync(
+          `sharinpix/forms/${safeFilename}.json`,
+          JSON.stringify(
+            form,
+            function (key: string, value: unknown): unknown {
+              return key === 'uuid' && this === form ? undefined : value;
+            },
+            2
+          )
+        );
         this.log(messages.getMessage('info.hello', [record.Name, record.sharinpix__FormUrl__c]));
         formsDownloaded++;
       } catch (error) {

--- a/test/commands/sharinpix/form/pull.test.ts
+++ b/test/commands/sharinpix/form/pull.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { TestContext } from '@salesforce/core/testSetup';
 import { expect } from 'chai';
 import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
@@ -70,7 +71,11 @@ describe('sharinpix form pull', () => {
     const fetchStub = $$.SANDBOX.stub();
     fetchStub.onCall(0).resolves({
       ok: true,
-      json: async () => ({ name: 'Form 1', data: 'test' }),
+      json: async () => ({
+        name: 'Form 1',
+        uuid: 'org-a-uuid',
+        data: 'test',
+      }),
       status: 200,
       statusText: 'OK',
     });
@@ -81,9 +86,18 @@ describe('sharinpix form pull', () => {
     });
     global.fetch = fetchStub;
 
+    const writeFileSyncStub = $$.SANDBOX.stub(fs, 'writeFileSync');
+
     const result = await pullInstance.run();
 
     expect(result.formsDownloaded).to.equal(1);
     expect(result.formsFailed).to.equal(1);
+
+    const writtenJson = JSON.parse(writeFileSyncStub.firstCall.args[1] as string) as Record<string, unknown>;
+    expect(writtenJson).to.not.have.property('uuid');
+    expect(writtenJson).to.deep.equal({
+      name: 'Form 1',
+      data: 'test',
+    });
   });
 });


### PR DESCRIPTION
## Summary
When pulling a form from an org, the downloaded JSON includes a `uuid` tied to that org. Pushing that same file to a different org keeps the first org's uuid, which causes "access denied" on the form editor.

This strips `uuid` from the form JSON at pull time, so pulled files no longer carry an org-specific uuid.

## Test Locally
1.  Checkout pull request.

2. Run the following commands:
  ```
  # Remove the npm-installed version to avoid a naming conflict
  sf plugins uninstall @sharinpix/sharinpix-sf-cli
  
  yarn install
  yarn build
  sf plugins link .
  
  sf sharinpix form pull -o <org>
  ```